### PR TITLE
Adopt ceil method for ios inapp prices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Start container
         run: |
-          docker-compose -f ./.ci/docker-compose-ci.yml up -d
+          docker compose -f ./.ci/docker-compose-ci.yml up -d
       - name: Install dependencies
         run: |
           docker exec -t ecommerce_testing bash -c "

--- a/ecommerce/extensions/iap/api/v1/constants.py
+++ b/ecommerce/extensions/iap/api/v1/constants.py
@@ -7,6 +7,7 @@ DISABLE_REDUNDANT_PAYMENT_CHECK_MOBILE_SWITCH_NAME = "disable_redundant_payment_
 ERROR_ALREADY_PURCHASED = "You have already purchased these products"
 ERROR_BASKET_NOT_FOUND = "Basket [{}] not found."
 ERROR_BASKET_ID_NOT_PROVIDED = "Basket id is not provided"
+ERROR_USER_CANCELLED_PAYMENT = "User cancelled this payment."
 ERROR_DURING_IOS_REFUND_EXECUTION = "Could not execute IOS refund."
 ERROR_DURING_ORDER_CREATION = "An error occurred during order creation."
 ERROR_DURING_PAYMENT_HANDLING = "An error occurred during payment handling."
@@ -32,6 +33,8 @@ LOGGER_BASKET_NOT_FOUND = "Basket [%s] not found for user [%s]."
 LOGGER_CHECKOUT_ERROR = "Checkout failed with the error [%s] and status code [%s]."
 LOGGER_EXECUTE_ALREADY_PURCHASED = "Execute payment failed for user [%s] and basket [%s]. " \
                                    "Products already purchased."
+LOGGER_EXECUTE_CANCELLED_PAYMENT_ERROR = "Execute payment failed for user [%s] and basket [%s]. " \
+                                         "Payment error [%s]."
 LOGGER_EXECUTE_GATEWAY_ERROR = "Execute payment validation failed for user [%s] and basket [%s]. Error: [%s]"
 LOGGER_EXECUTE_ORDER_CREATION_FAILED = "Execute payment failed for user [%s] and basket [%s]. " \
                                        "Order Creation failed with error [%s]."

--- a/ecommerce/extensions/iap/api/v1/tests/test_utils.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_utils.py
@@ -85,7 +85,7 @@ class TestCreateIosProducts(TestCase):
             'price': 1001
         }
         error_msg = create_ios_product(course, self.ios_seat, self.configuration)
-        self.assertEqual(error_msg, 'Error: Appstore does not allow price> 1000')
+        self.assertEqual(error_msg, 'Error: Appstore does not allow price > 1000')
 
     def test_create_ios_product_with_failure(self, _):
         course = {

--- a/ecommerce/extensions/iap/api/v1/tests/test_utils.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_utils.py
@@ -149,6 +149,7 @@ class TestCreateIosProducts(TestCase):
                 apply_price_of_inapp_purchase(100, '123', headers)
 
             get_call.return_value.status_code = 200
+            post_call.return_value.status_code = 201
             get_call.return_value.json.return_value = {
                 'data': [
                     {
@@ -159,12 +160,11 @@ class TestCreateIosProducts(TestCase):
                     }
                 ]
             }
-            with self.assertRaises(AppStoreRequestException, msg="Couldn't find nearest low price point"):
-                # Make sure it doesn't select higher price point
-                apply_price_of_inapp_purchase(80, '123', headers)
+            with self.assertRaises(AppStoreRequestException, msg="Couldn't find nearest high price point"):
+                # Make sure it doesn't select lower price point
+                apply_price_of_inapp_purchase(100, '123', headers)
 
-            post_call.return_value.status_code = 201
-            apply_price_of_inapp_purchase(100, '123', headers)
+            apply_price_of_inapp_purchase(98, '123', headers)
             price_url = 'https://api.appstoreconnect.apple.com/v1/inAppPurchasePriceSchedules'
             self.assertEqual(post_call.call_args[0][0], price_url)
             self.assertEqual(post_call.call_args[1]['headers'], headers)

--- a/ecommerce/extensions/iap/api/v1/tests/test_utils.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_utils.py
@@ -73,17 +73,25 @@ class TestCreateIosProducts(TestCase):
         course = {
             'key': 'test',
             'name': 'test',
-            'price': '123'
+            'price': 123
         }
         error_msg = create_ios_product(course, self.ios_seat, self.configuration)
         self.assertEqual(error_msg, None)
 
-    # @mock.patch('ecommerce.extensions.iap.api.v1.utils.create_inapp_purchase')
+    def test_error_on_ios_product_price_threshhold(self, _,):
+        course = {
+            'key': 'test',
+            'name': 'test',
+            'price': 1001
+        }
+        error_msg = create_ios_product(course, self.ios_seat, self.configuration)
+        self.assertEqual(error_msg, 'Error: Appstore does not allow price> 1000')
+
     def test_create_ios_product_with_failure(self, _):
         course = {
             'key': 'test',
             'name': 'test',
-            'price': '123'
+            'price': 123
         }
         error_msg = create_ios_product(course, self.ios_seat, self.configuration)
         expected_msg = "[Couldn't create inapp purchase id]  for course [{}] with sku [{}]".format(
@@ -110,7 +118,7 @@ class TestCreateIosProducts(TestCase):
             course = {
                 'key': 'test',
                 'name': 'test',
-                'price': '123'
+                'price': 123
             }
             headers = get_auth_headers(self.configuration)
             create_inapp_purchase(course, 'test.sku', '123', headers)

--- a/ecommerce/extensions/iap/api/v1/utils.py
+++ b/ecommerce/extensions/iap/api/v1/utils.py
@@ -188,15 +188,16 @@ def apply_price_of_inapp_purchase(price, in_app_purchase_id, headers):
     if response.status_code != 200:
         raise AppStoreRequestException("Couldn't fetch price points")
 
-    nearest_low_price = nearest_low_price_id = 0
+    # Apple doesn't allow in app price > 1000
+    nearest_high_price = nearest_high_price_id = 1001
     for price_point in response.json()['data']:
         customer_price = float(price_point['attributes']['customerPrice'])
-        if nearest_low_price < customer_price <= price:
-            nearest_low_price = customer_price
-            nearest_low_price_id = price_point['id']
+        if nearest_high_price > customer_price >= price:
+            nearest_high_price = customer_price
+            nearest_high_price_id = price_point['id']
 
-    if not nearest_low_price:
-        raise AppStoreRequestException("Couldn't find nearest low price point")
+    if nearest_high_price == 1001:
+        raise AppStoreRequestException("Couldn't find nearest high price point")
 
     url = APP_STORE_BASE_URL + "/v1/inAppPurchasePriceSchedules"
     data = {
@@ -233,7 +234,7 @@ def apply_price_of_inapp_purchase(price, in_app_purchase_id, headers):
                     "inAppPurchasePricePoint": {
                         "data": {
                             "type": "inAppPurchasePricePoints",
-                            "id": nearest_low_price_id
+                            "id": nearest_high_price_id
                         }
                     }
                 },

--- a/ecommerce/extensions/iap/api/v1/utils.py
+++ b/ecommerce/extensions/iap/api/v1/utils.py
@@ -34,6 +34,9 @@ def create_ios_product(course, ios_product, configuration):
     Create in app ios product on connect store.
     return error message in case of failure.
     """
+    if course['price'] > 1000:
+        return 'Error: Appstore does not allow price> 1000'
+
     headers = get_auth_headers(configuration)
     try:
         in_app_purchase_id = get_or_create_inapp_purchase(ios_product, course, configuration, headers)

--- a/ecommerce/extensions/iap/api/v1/utils.py
+++ b/ecommerce/extensions/iap/api/v1/utils.py
@@ -35,7 +35,7 @@ def create_ios_product(course, ios_product, configuration):
     return error message in case of failure.
     """
     if course['price'] > 1000:
-        return 'Error: Appstore does not allow price> 1000'
+        return 'Error: Appstore does not allow price > 1000'
 
     headers = get_auth_headers(configuration)
     try:

--- a/ecommerce/extensions/iap/processors/base_iap.py
+++ b/ecommerce/extensions/iap/processors/base_iap.py
@@ -212,6 +212,7 @@ class BaseIAP(BasePaymentProcessor):
                                                                             basket=basket)
 
         meta_data = self._get_metadata(currency_code=currency_code, price=price)
+        original_transaction_id = original_transaction_id or transaction_id
         PaymentProcessorResponseExtension.objects.create(
             processor_response=processor_response, original_transaction_id=original_transaction_id,
             meta_data=meta_data)


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [ ] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description
Adopt ceil method for ios inapp prices i.e. pick closest higher price point for an inapp purchase. And if course price is > 1000 then don't apply price for this product. 
Previously for android purchases we were not storing transaction ids in paymentresponseextension table, this change will also fix this issue.
For user cancelled payments return user cancelled error in execute api view.


## Supporting information

Jira Ticket: https://2u-internal.atlassian.net/browse/LEARNER-10095
