### PR TITLE
Removed apple auth headers from screenshot upload api

### DIFF
--- a/ecommerce/extensions/iap/api/v1/tests/test_utils.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_utils.py
@@ -225,8 +225,7 @@ class TestCreateIosProducts(TestCase):
             self.assertEqual(post_call.call_args[1]['headers'], headers)
 
             self.assertEqual(put_call.call_args[0][0], 'https://image-url.com')
-            img_headers = headers.copy()
-            img_headers['Content-Type'] = 'image/png'
+            img_headers = {'Content-Type': 'image/png'}
             self.assertEqual(put_call.call_args[1]['headers'], img_headers)
 
             img_patch_url = 'https://api.appstoreconnect.apple.com/v1/inAppPurchaseAppStoreReviewScreenshots/1234'

--- a/ecommerce/extensions/iap/api/v1/utils.py
+++ b/ecommerce/extensions/iap/api/v1/utils.py
@@ -282,8 +282,7 @@ def upload_screenshot_of_inapp_purchase(in_app_purchase_id, headers):
     screenshot_id = response['data']['id']
     url = response['data']['attributes']['uploadOperations'][0]['url']
     with staticfiles_storage.open('images/mobile_ios_product_screenshot.png', 'rb') as image:
-        img_headers = headers.copy()
-        img_headers['Content-Type'] = 'image/png'
+        img_headers = {'Content-Type': 'image/png'}
         response = request_connect_store(url, headers=img_headers, data=image.read(), method='put')
 
         if response.status_code != 200:


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [ ] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description
Removed apple auth headers from screenshot upload api. Api started failing abruptly, removing apple auth headers fixed the issue in this case.

Useful information to include:
- This will effect mobile enabled courses for mobile users.

## Supporting information
Jira Ticket: https://2u-internal.atlassian.net/browse/LEARNER-10170

