### PR TITLE
chore: Removed mobile iap depricated code

### DIFF
--- a/ecommerce/extensions/iap/api/v1/google_validator.py
+++ b/ecommerce/extensions/iap/api/v1/google_validator.py
@@ -13,8 +13,7 @@ class GooglePlayValidator:
         Accepts receipt, validates that the purchase has already been completed in
         Google for the mentioned product_id.
         """
-        # purchaseToken will be removed in coming releases in favour of purchase_token
-        purchase_token = receipt.get('purchase_token', receipt.get('purchaseToken'))
+        purchase_token = receipt.get('purchase_token')
         # Mobile assumes one course is purchased at a time
         product_sku = get_consumable_android_sku(basket.total_excl_tax)
         verifier = GooglePlayVerifier(
@@ -23,20 +22,13 @@ class GooglePlayValidator:
         )
         try:
             result = self.verify_result(verifier, purchase_token, product_sku)
-        except errors.GoogleError:
-            logger.error('Purchase validation failed, Now moving to fallback approach for non consumable skus')
+        except errors.GoogleError as exc:
+            logger.error('Purchase validation failed %s', exc)
+            result = {
+                'error': exc.raw_response,
+                'message': exc.message
+            }
 
-            try:
-                # Fallback to the old approach and verify token with partner_sku
-                # This fallback is temporary until all android products are switched to consumable products.
-                sku = basket.all_lines().first().stockrecord.partner_sku
-                result = self.verify_result(verifier, purchase_token, sku)
-            except errors.GoogleError as exc:
-                logger.error('Purchase validation failed %s', exc)
-                result = {
-                    'error': exc.raw_response,
-                    'message': exc.message
-                }
         return result
 
     def verify_result(self, verifier, purchase_token, product_sku):

--- a/ecommerce/extensions/iap/api/v1/ios_validator.py
+++ b/ecommerce/extensions/iap/api/v1/ios_validator.py
@@ -18,7 +18,7 @@ class IOSValidator:
 
         try:
             validation_result = validator.validate(
-                receipt.get('purchase_token', receipt.get('purchaseToken')),
+                receipt.get('purchase_token'),
                 exclude_old_transactions=True  # if True, include only the latest renewal transaction
             )
         except InAppPyValidationError as ex:

--- a/ecommerce/extensions/iap/api/v1/tests/test_google_validator.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_google_validator.py
@@ -42,7 +42,7 @@ class GoogleValidatorTests(TestCase):
         "purchase_token": VALID_PURCHASE_TOKEN,
     }
     INVALID_RECEIPT = {
-        "purchaseToken": INVALID_PURCHASE_TOKEN,
+        "purchase_token": INVALID_PURCHASE_TOKEN,
     }
     CONFIGURATION = {
         "google_bundle_id": "test.google.bundle.id",
@@ -77,11 +77,6 @@ class GoogleValidatorTests(TestCase):
                 (
                     logger_name,
                     'ERROR',
-                    "Purchase validation failed, Now moving to fallback approach for non consumable skus"
-                ),
-                (
-                    logger_name,
-                    'ERROR',
                     "Purchase validation failed {}".format(
                         'GoogleError None None'
                     ),
@@ -89,21 +84,3 @@ class GoogleValidatorTests(TestCase):
             )
             self.assertIn('error', response)
             self.assertIn('message', response)
-
-    @mock.patch('ecommerce.extensions.iap.api.v1.google_validator.GooglePlayVerifier')
-    def test_validate_failure_for_consumable_sku(self, mock_google_verifier):
-        logger_name = 'ecommerce.extensions.iap.api.v1.google_validator'
-        with mock.patch.object(GooglePlayVerifierProxy, 'verify_with_result',
-                               side_effect=[errors.GoogleError(), GooglePlayVerifierResponse()]), \
-                LogCapture(logger_name) as google_validator_log_capture:
-            mock_google_verifier.return_value = GooglePlayVerifierProxy()
-
-            response = self.validator.validate(self.INVALID_RECEIPT, self.CONFIGURATION, self.basket)
-            google_validator_log_capture.check_present(
-                (
-                    logger_name,
-                    'ERROR',
-                    "Purchase validation failed, Now moving to fallback approach for non consumable skus"
-                ),
-            )
-            self.assertEqual(response, self.VALIDATED_RESPONSE)

--- a/ecommerce/extensions/iap/api/v1/tests/test_ios_validator.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_ios_validator.py
@@ -28,10 +28,10 @@ class IOSValidatorTests(TestCase):
     """ IOS Validator Tests """
 
     VALID_RECEIPT = {
-        "purchaseToken": VALID_PURCHASE_TOKEN,
+        "purchase_token": VALID_PURCHASE_TOKEN,
     }
     INVALID_RECEIPT = {
-        "purchaseToken": INVALID_PURCHASE_TOKEN,
+        "purchase_token": INVALID_PURCHASE_TOKEN,
     }
 
     def setUp(self):

--- a/ecommerce/extensions/iap/api/v1/tests/test_views.py
+++ b/ecommerce/extensions/iap/api/v1/tests/test_views.py
@@ -300,7 +300,7 @@ class MobileCoursePurchaseExecutionViewTests(PaymentEventsMixin, TestCase):
         self.logger_name = 'ecommerce.extensions.iap.api.v1.views'
 
         self.post_data = {
-            'purchaseToken': 'inapp:org.edx.mobile:android.test.purchased',
+            'purchase_token': 'inapp:org.edx.mobile:android.test.purchased',
             'payment_processor': 'android-iap',
             'basket_id': self.basket.id
         }

--- a/ecommerce/extensions/iap/tests/processors/test_ios_iap.py
+++ b/ecommerce/extensions/iap/tests/processors/test_ios_iap.py
@@ -58,7 +58,7 @@ class IOSIAPTests(PaymentProcessorTestCaseMixin, TestCase):
         )
         self.product_sku = self.product.stockrecords.first().partner_sku
         self.RETURN_DATA = {
-            'purchaseToken': 'inapp:test.edx.edx:ios.test.purchased',
+            'purchase_token': 'inapp:test.edx.edx:ios.test.purchased',
             'price': 40.25,
             'currency_code': 'USD',
         }


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [ ] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

Removed iap deprecated code. In android we have shifted to consumable approach and it is safe to remove consumable fallback approach.

## Supporting information

Jira tiket: https://2u-internal.atlassian.net/browse/LEARNER-9940

