### PR TITLE
fix: Disable mobile payment refunds from ecommerce

### DIFF
--- a/ecommerce/extensions/dashboard/orders/views.py
+++ b/ecommerce/extensions/dashboard/orders/views.py
@@ -87,6 +87,4 @@ class OrderDetailView(CoreOrderDetailView):
         return self.reload_page()
 
     def _is_order_from_mobile(self, order):
-        processor_responses = order.basket.paymentprocessorresponse_set.all()
-        return any(response.processor_name in MOBILE_PAYMENT_PROCESSORS
-                   for response in processor_responses)
+        return order.basket.paymentprocessorresponse_set.filter(processor_name__in=MOBILE_PAYMENT_PROCESSORS).exists()

--- a/ecommerce/extensions/dashboard/orders/views.py
+++ b/ecommerce/extensions/dashboard/orders/views.py
@@ -9,6 +9,7 @@ from oscar.apps.dashboard.orders.views import OrderListView as CoreOrderListView
 from oscar.core.loading import get_model
 
 from ecommerce.extensions.dashboard.views import FilterFieldsMixin
+from ecommerce.extensions.iap.constants import MOBILE_PAYMENT_PROCESSORS
 
 Order = get_model('order', 'Order')
 Partner = get_model('partner', 'Partner')
@@ -62,20 +63,30 @@ class OrderDetailView(CoreOrderDetailView):
     line_actions = ('change_line_statuses', 'create_shipping_event', 'create_payment_event', 'create_refund')
 
     def create_refund(self, request, order, lines, _quantities):  # pylint: disable=unused-argument
-        refund = Refund.create_with_lines(order, lines)
-
-        if refund:
-            data = {
-                'link_start': '<a href="{}" target="_blank">'.format(
-                    reverse('dashboard:refunds-detail', kwargs={'pk': refund.pk})),
-                'link_end': '</a>',
-                'refund_id': refund.pk
-            }
-            message = _('{link_start}Refund #{refund_id}{link_end} created! '
-                        'Click {link_start}here{link_end} to view it.').format(**data)
-            messages.success(request, mark_safe(message))
-        else:
-            message = _('A refund cannot be created for these lines. They may have already been refunded.')
+        if self._is_order_from_mobile(order):
+            message = _("Mobile payment refunds aren't allowed in ecommerce.")
             messages.error(request, message)
 
+        else:
+            refund = Refund.create_with_lines(order, lines)
+
+            if refund:
+                data = {
+                    'link_start': '<a href="{}" target="_blank">'.format(
+                        reverse('dashboard:refunds-detail', kwargs={'pk': refund.pk})),
+                    'link_end': '</a>',
+                    'refund_id': refund.pk
+                }
+                message = _('{link_start}Refund #{refund_id}{link_end} created! '
+                            'Click {link_start}here{link_end} to view it.').format(**data)
+                messages.success(request, mark_safe(message))
+            else:
+                message = _('A refund cannot be created for these lines. They may have already been refunded.')
+                messages.error(request, message)
+
         return self.reload_page()
+
+    def _is_order_from_mobile(self, order):
+        processor_responses = order.basket.paymentprocessorresponse_set.all()
+        return any(response.processor_name in MOBILE_PAYMENT_PROCESSORS
+                   for response in processor_responses)

--- a/ecommerce/extensions/iap/constants.py
+++ b/ecommerce/extensions/iap/constants.py
@@ -1,3 +1,4 @@
+MOBILE_PAYMENT_PROCESSORS = ['android-iap', 'ios-iap']
 ANDROID_SKU_PREFIX = 'android'
 IOS_SKU_PREFIX = 'ios'
 MISSING_WEB_SEAT_ERROR = "Couldn't find existing web seat for course [%s]"


### PR DESCRIPTION
# ⛔️ MAIN BRANCH WARNING! 2U EMPLOYEES must make branches against the 2u/main BRANCH

- [ ] I have checked the branch to which I would like to merge.

# ⛔️ DEPRECATION WARNING

**This repository is deprecated and in maintainence-only operation while we work on a replacement, please see [this announcement](https://discuss.openedx.org/t/deprecation-removal-ecommerce-service-depr-22/6839) for more information.**

Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to [security@edx.org](mailto:security@edx.org)

<!--
Please give the pull request a short but descriptive title.

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
-->

## Anyone internally merging to this repository is expected to [release and monitor their changes](https://openedx.atlassian.net/wiki/spaces/RS/pages/1835106870/How+to+contribute+to+our+repositories); if you are not able to do this DO NOT MERGE, please coordinate with someone who can to ensure that the changes are released.

## Required Testing
- [ ] Before deploying this change, complete a purchase in the stage environment. 
(^ We can remove that manual check once REV-2624 is done and the corresponding e2e test runs again)

## Description

The process for mobile refunds follows a distinct flow that requires users to visit the relevant app store to receive their refunds. However, there are instances where the support team mistakenly processes refunds through the eCommerce platform, which is not the correct procedure. To address this, the eCommerce refund option for the support team is being disabled in this PR. 

Useful information to include:
- This will effect support team which apply for refunds in ecommerce.

## Supporting information

Jira Ticket: https://2u-internal.atlassian.net/browse/LEARNER-9948
